### PR TITLE
Adding postinstall to react-native-ticker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "yarn build",
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "yarn build"
   },
   "author": "Jason Brown (browniefed)",
   "license": "MIT",


### PR DESCRIPTION
typescript needs to be compiled when installing this dependency on the edge-gui project, this module cannot be installed otherwise